### PR TITLE
Directly return data array when calling converter

### DIFF
--- a/src/handlers/converter.js
+++ b/src/handlers/converter.js
@@ -13,7 +13,8 @@ async function convert(options = {}) {
 		sourceFile = optionsUtils.get(options, optionsUtils.OPTION_KEYS.SOURCE_FILE),
 		targetFolder = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TARGET_FOLDER),
 		targetFilename = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TARGET_TEXT_FILENAME),
-		targetCppFilename = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TARGET_CPP_FILENAME);
+		targetCppFilename = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TARGET_CPP_FILENAME),
+		returnArray = optionsUtils.get(options, optionsUtils.OPTION_KEYS.RETURN_ARRAY, false);
 
 	try {
 		await fileUtils.isFileReadable(sourceFile);
@@ -22,6 +23,10 @@ async function convert(options = {}) {
 		bitmap = imageUtils.modifyPicture(bitmap, options);
 
 		let tasks = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TASKS, 'binary');
+
+		if (Array.isArray(tasks) && returnArray) {
+			throw "can only return Array of one task!";
+		}
 
 		if (!Array.isArray(tasks)) {
 			tasks = [ tasks ];
@@ -41,18 +46,18 @@ async function convert(options = {}) {
 				case 'binary':
 					binaryPixelArray = numberUtils.getBinaryPixelArray(bitmap, options);
 
-					fileContent += numberUtils.getBinaryPixelArrayString(binaryPixelArray);
+					if (!returnArray) fileContent += numberUtils.getBinaryPixelArrayString(binaryPixelArray);
 					break;
 				case 'hexadecimal':
 					hexaPixelArray = numberUtils.getHexaPixelArray(bitmap, options);
 
-					fileContent += numberUtils.getHexaPixelArrayString(hexaPixelArray);
+					if (!returnArray) fileContent += numberUtils.getHexaPixelArrayString(hexaPixelArray);
 					break;
 				case 'hexadecimal_cpp':
 					hexaPixelArray = numberUtils.getHexaPixelArray(bitmap, options);
 
-					cppHeaderFileContent = cppUtils.createCHeaderContent(options);
-					cppMainFileContent = cppUtils.createCMainContent(hexaPixelArray, options);
+					if (!returnArray) cppHeaderFileContent = cppUtils.createCHeaderContent(options);
+					if (!returnArray) cppMainFileContent = cppUtils.createCMainContent(hexaPixelArray, options);
 					break;
 				default:
 					break;
@@ -70,7 +75,9 @@ async function convert(options = {}) {
 			await fileUtils.writeContentToFile(targetCppFileRoot + fileUtils.EXTENSIONS.CPP_MAIN, cppMainFileContent);
 		}
 
-		console.log('Successfully converted the given image file! Source file: ' + sourceFile, ', target folder: ' + targetFolder);
+		if (!returnArray) console.log('Successfully converted the given image file! Source file: ' + sourceFile, ', target folder: ' + targetFolder);
+		if (returnArray && binaryPixelArray) return binaryPixelArray;
+		if (returnArray && hexaPixelArray) return hexaPixelArray;
 	} catch (err) {
 		console.error(err);
 	}

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -7,6 +7,8 @@ const OPTION_KEYS = {
 	TARGET_CPP_FILENAME: 'target_cpp_filename', // Filename wothout extension, placed in the target folder
 	CPP_VARIABLE_NAME: 'cpp_variable_name', // Filename wothout extension, placed in the target folder
 	TASKS: 'tasks', // 'binary', 'hexadecimal', 'hexadecimal_cpp'
+	RETURN_ARRAY: 'return_array', // boolean if data is directly returned or written to file
+
 
 	DISPLAY_WIDTH: 'display.width', // numbers
 	DISPLAY_HEIGHT: 'display.height', // numbers


### PR DESCRIPTION
I've written a little hacky modification of your great tool to allow direct return of the data without writing to a file. This way you can pass the data along and for example send it to your ePaper via websockets.
Example Code:
```
converter.convert({
        source_file: "./img/" + path,
        target_folder: "./output",
        target_text_filename: "picture.txt",
        target_cpp_filename: "picture",
        cpp_variable_name: "PICTURE",
        tasks: "hexadecimal",
        return_array: true,
        display: {
            "width": 104,
            "height": 212,
            "fitmode": "none",
            "colormode": "inverted"
        }
    }).then(payload => socket.emit('image', payload));
```