### PR TITLE
pass a new bitmap instead reading from file

### DIFF
--- a/src/handlers/converter.js
+++ b/src/handlers/converter.js
@@ -14,11 +14,11 @@ async function convert(options = {}) {
 		targetFolder = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TARGET_FOLDER),
 		targetFilename = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TARGET_TEXT_FILENAME),
 		targetCppFilename = optionsUtils.get(options, optionsUtils.OPTION_KEYS.TARGET_CPP_FILENAME),
-		readFromFile = optionsUtils.get(optionsUtils, optionsUtils.READ_FROM_FILE);
+		readFromFile = optionsUtils.get(optionsUtils, optionsUtils.READ_FROM_FILE, true);
 
 
 	try {
-		if (options.read_from_file) {
+		if (readFromFile) {
 			await fileUtils.isFileReadable(sourceFile);
 			await bitmap.readFile(sourceFile);
 		} else {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -7,6 +7,7 @@ const OPTION_KEYS = {
 	TARGET_CPP_FILENAME: 'target_cpp_filename', // Filename wothout extension, placed in the target folder
 	CPP_VARIABLE_NAME: 'cpp_variable_name', // Filename wothout extension, placed in the target folder
 	TASKS: 'tasks', // 'binary', 'hexadecimal', 'hexadecimal_cpp'
+	READ_FROM_FILE: read_from_file,
 
 	DISPLAY_WIDTH: 'display.width', // numbers
 	DISPLAY_HEIGHT: 'display.height', // numbers


### PR DESCRIPTION
This allows for feeding in images which have been virtually created like a canvas. Using ImageJS and [Node Canvas](https://github.com/Automattic/node-canvas) library, here's some example code:

```
canvasToImage = canvas => {
    return new Promise((resolve, reject) => {
        const stream = canvas.createJPEGStream();
        const bitmap = new ImageJS.Bitmap();
        bitmap.read(stream, { type: ImageJS.ImageType.JPG })
            .then(function() {
                console.log("yay");
                resolve(bitmap);
                // bitmap is ready
            }).catch(error => reject(error)
        );
    });
};

// create a canvas
const canvas = Canvas.createCanvas(104, 212); 

// ... draw something on your canvas...

// convert the canvas to a Bitmap and finally to a hexadecimal array
canvasToImage(canvas).then(image =>
    converter.convert({
            target_folder: "./output",
            target_text_filename: "picture.txt",
            tasks: "hexadecimal",
            read_from_file: false,
            bitmap: image,
            display: {
                "width": 104,
                "height": 212,
                "fitmode": "none",
                "colormode": "inverted"
            }
        })
```